### PR TITLE
Add Stock Research Desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ For a **complete autonomous financial analysis framework**, check out:
 
 **[DeepEar →](https://github.com/RKiding/AlphaEar)**
 
+For a terminal-first **multi-agent equity research desk** with theme screening, watchlists, one-DOCX memo delivery, and a Codex skill mode, see:
+
+**[Stock Research Desk →](https://github.com/wd041216-bit/stock-research-desk)**
+
 ---
 
 <a name="中文"></a>
@@ -174,6 +178,10 @@ cp -r Awesome-finance-skills/skills/* ~/.config/opencode/skills/
 如需**完整的自动化金融分析框架**，请关注：
 
 **[DeepEar →](https://github.com/RKiding/AlphaEar)**
+
+如需一个终端优先的**多 Agent 股票研究工作台**，支持主题筛选、watchlist、单 DOCX 研报交付和 Codex Skill 模式，也可以参考：
+
+**[Stock Research Desk →](https://github.com/wd041216-bit/stock-research-desk)**
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Stock Research Desk](https://github.com/wd041216-bit/stock-research-desk) as a related finance agent project in both the English and Chinese sections.

## Why it fits

- terminal-first multi-agent equity research desk
- supports theme screening, watchlists, one-DOCX memo delivery, and a Codex skill mode
- complementary to finance-agent skill workflows without changing this repo's existing skill list

## Public references

- [Project Showcase](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/showcase.md)
- [Sample Research Memo](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-memo.md)
- [Sample Screening Summary](https://github.com/wd041216-bit/stock-research-desk/blob/main/docs/sample-screening.md)
