### PR TITLE
feat: add trade-terminal — personal trading dashboard with AI analysis

### DIFF
--- a/trade-terminal/backend/.env.example
+++ b/trade-terminal/backend/.env.example
@@ -1,0 +1,26 @@
+# ── AI ───────────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-...
+
+# ── Market Data (ücretsiz kayıt gerekiyor) ──
+# https://finnhub.io → ücretsiz API key
+FINNHUB_API_KEY=
+
+# https://twelvedata.com → ücretsiz, 800 req/gün
+TWELVE_DATA_API_KEY=
+
+# https://www.alphavantage.co → ücretsiz, 25 req/gün
+ALPHA_VANTAGE_API_KEY=
+
+# https://fred.stlouisfed.org/docs/api → tamamen ücretsiz
+FRED_API_KEY=
+
+# ── Bot Paths ────────────────────────────────
+BOTS_DIR=./bots
+BOT_LOGS_DIR=./logs/bots
+BOT_CONFIGS_DIR=./configs/bots
+
+# ── Server ───────────────────────────────────
+HOST=0.0.0.0
+PORT=8000
+FRONTEND_URL=http://localhost:3000
+DB_PATH=./data/terminal.db

--- a/trade-terminal/backend/config.py
+++ b/trade-terminal/backend/config.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# API Keys
+ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
+FINNHUB_API_KEY = os.getenv("FINNHUB_API_KEY", "")
+TWELVE_DATA_API_KEY = os.getenv("TWELVE_DATA_API_KEY", "")
+ALPHA_VANTAGE_API_KEY = os.getenv("ALPHA_VANTAGE_API_KEY", "")
+FRED_API_KEY = os.getenv("FRED_API_KEY", "")
+
+# Bot settings
+BOTS_DIR = Path(os.getenv("BOTS_DIR", "./bots"))
+BOT_LOGS_DIR = Path(os.getenv("BOT_LOGS_DIR", "./logs/bots"))
+BOT_CONFIGS_DIR = Path(os.getenv("BOT_CONFIGS_DIR", "./configs/bots"))
+
+# Server
+HOST = os.getenv("HOST", "0.0.0.0")
+PORT = int(os.getenv("PORT", "8000"))
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+# DB
+DB_PATH = os.getenv("DB_PATH", "./data/terminal.db")

--- a/trade-terminal/backend/main.py
+++ b/trade-terminal/backend/main.py
@@ -1,0 +1,49 @@
+import asyncio
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, WebSocket
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
+
+from config import FRONTEND_URL
+from routers import bots, market, analysis
+from ws.live_feed import handle_connection, start_price_poller
+from services.bot_manager import init_db
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await init_db()
+    await start_price_poller(interval=5)
+    yield
+
+
+app = FastAPI(title="Trade Terminal API", version="1.0.0", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[FRONTEND_URL, "http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(bots.router)
+app.include_router(market.router)
+app.include_router(analysis.router)
+
+
+@app.websocket("/ws/live")
+async def websocket_live(ws: WebSocket):
+    await handle_connection(ws)
+
+
+@app.get("/api/health")
+async def health():
+    return {"status": "ok"}
+
+
+# Serve Next.js static build if it exists
+_static = Path(__file__).parent.parent / "frontend" / "out"
+if _static.exists():
+    app.mount("/", StaticFiles(directory=str(_static), html=True), name="frontend")

--- a/trade-terminal/backend/requirements.txt
+++ b/trade-terminal/backend/requirements.txt
@@ -1,0 +1,10 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+websockets>=12.0
+httpx>=0.27.0
+aiosqlite>=0.20.0
+python-dotenv>=1.0.0
+anthropic>=0.28.0
+pydantic>=2.7.0
+yfinance>=0.2.40
+aiofiles>=23.2.1

--- a/trade-terminal/backend/routers/analysis.py
+++ b/trade-terminal/backend/routers/analysis.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+from services.fundamental_data import get_full_fundamental, get_macro_snapshot
+from services.ai_analyst import analyze_fundamental, analyze_macro, chat_analyst
+
+router = APIRouter(prefix="/api/analysis", tags=["analysis"])
+
+
+class AnalysisRequest(BaseModel):
+    symbol: str
+    question: str = ""
+
+
+class MacroRequest(BaseModel):
+    question: str = ""
+
+
+class ChatMessage(BaseModel):
+    role: str  # "user" | "assistant"
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: list[ChatMessage]
+    symbol: Optional[str] = None
+
+
+@router.post("/fundamental")
+async def fundamental_analysis(req: AnalysisRequest):
+    data = await get_full_fundamental(req.symbol.upper())
+    result = await analyze_fundamental(req.symbol.upper(), data, req.question)
+    result["raw_data"] = data
+    return result
+
+
+@router.get("/fundamental/{symbol}")
+async def fundamental_analysis_get(symbol: str, question: str = ""):
+    data = await get_full_fundamental(symbol.upper())
+    result = await analyze_fundamental(symbol.upper(), data, question)
+    result["raw_data"] = data
+    return result
+
+
+@router.post("/macro")
+async def macro_analysis(req: MacroRequest):
+    data = await get_macro_snapshot()
+    if "error" in data:
+        raise HTTPException(400, data["error"])
+    return await analyze_macro(data, req.question)
+
+
+@router.get("/macro")
+async def macro_analysis_get(question: str = ""):
+    data = await get_macro_snapshot()
+    if "error" in data:
+        raise HTTPException(400, data["error"])
+    return await analyze_macro(data, question)
+
+
+@router.post("/chat")
+async def analyst_chat(req: ChatRequest):
+    context = None
+    if req.symbol:
+        context = await get_full_fundamental(req.symbol.upper())
+    messages = [{"role": m.role, "content": m.content} for m in req.messages]
+    reply = await chat_analyst(messages, context)
+    return {"reply": reply}

--- a/trade-terminal/backend/routers/bots.py
+++ b/trade-terminal/backend/routers/bots.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+import services.bot_manager as bm
+
+router = APIRouter(prefix="/api/bots", tags=["bots"])
+
+
+class RegisterBot(BaseModel):
+    id: str
+    name: str
+    script_path: str
+    description: str = ""
+
+
+class UpdateConfig(BaseModel):
+    config: dict
+
+
+@router.get("/")
+async def list_bots():
+    return await bm.list_bots()
+
+
+@router.post("/")
+async def register_bot(body: RegisterBot):
+    return await bm.register_bot(body.id, body.name, body.script_path, body.description)
+
+
+@router.get("/{bot_id}")
+async def get_bot(bot_id: str):
+    bot = await bm.get_bot(bot_id)
+    if not bot:
+        raise HTTPException(404, "Bot not found")
+    return bot
+
+
+@router.post("/{bot_id}/start")
+async def start_bot(bot_id: str):
+    try:
+        return await bm.start_bot(bot_id)
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+    except (RuntimeError, FileNotFoundError) as e:
+        raise HTTPException(400, str(e))
+
+
+@router.post("/{bot_id}/stop")
+async def stop_bot(bot_id: str):
+    try:
+        return await bm.stop_bot(bot_id)
+    except RuntimeError as e:
+        raise HTTPException(400, str(e))
+
+
+@router.put("/{bot_id}/config")
+async def update_config(bot_id: str, body: UpdateConfig):
+    bot = await bm.get_bot(bot_id)
+    if not bot:
+        raise HTTPException(404, "Bot not found")
+    return await bm.update_config(bot_id, body.config)
+
+
+@router.get("/{bot_id}/logs")
+async def get_logs(bot_id: str, lines: int = 100):
+    bot = await bm.get_bot(bot_id)
+    if not bot:
+        raise HTTPException(404, "Bot not found")
+    logs = await bm.get_logs(bot_id, lines)
+    return {"bot_id": bot_id, "logs": logs}
+
+
+@router.delete("/{bot_id}")
+async def delete_bot(bot_id: str):
+    bot = await bm.get_bot(bot_id)
+    if not bot:
+        raise HTTPException(404, "Bot not found")
+    await bm.delete_bot(bot_id)
+    return {"deleted": bot_id}

--- a/trade-terminal/backend/routers/market.py
+++ b/trade-terminal/backend/routers/market.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Query
+from services.market_data import get_quote, get_ohlcv, search_symbols
+
+router = APIRouter(prefix="/api/market", tags=["market"])
+
+
+@router.get("/quote/{symbol}")
+async def quote(symbol: str):
+    return await get_quote(symbol.upper())
+
+
+@router.get("/ohlcv/{symbol}")
+async def ohlcv(
+    symbol: str,
+    interval: str = Query("1day", description="1min,5min,15min,1h,4h,1day,1week"),
+    limit: int = Query(90, ge=10, le=500),
+):
+    data = await get_ohlcv(symbol.upper(), interval, limit)
+    return {"symbol": symbol.upper(), "interval": interval, "data": data}
+
+
+@router.get("/search")
+async def search(q: str = Query(..., min_length=1)):
+    return await search_symbols(q)
+
+
+@router.get("/quotes")
+async def multi_quote(symbols: str = Query(..., description="Comma-separated symbols")):
+    import asyncio
+    syms = [s.strip().upper() for s in symbols.split(",") if s.strip()]
+    results = await asyncio.gather(*[get_quote(s) for s in syms])
+    return {r["symbol"]: r for r in results}

--- a/trade-terminal/backend/services/ai_analyst.py
+++ b/trade-terminal/backend/services/ai_analyst.py
@@ -1,0 +1,174 @@
+"""
+Claude-powered fundamental analysis interpreter.
+Takes raw data → structured AI commentary.
+"""
+import anthropic
+import json
+from config import ANTHROPIC_API_KEY
+
+_client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+
+SYSTEM_PROMPT = """You are a senior equity research analyst with deep expertise in fundamental analysis, macroeconomics, and quantitative finance.
+
+Your job is to interpret financial data and provide clear, actionable insights. Be concise and direct. Structure your analysis in clear sections. Use bullet points. Flag risks prominently. Do not use fluff or filler phrases.
+
+Respond in the same language the user uses (Turkish or English)."""
+
+
+async def analyze_fundamental(symbol: str, data: dict, user_question: str = "") -> dict:
+    """
+    Takes fundamental data bundle and produces structured AI analysis.
+    """
+    import asyncio
+
+    question = user_question or f"Provide a comprehensive fundamental analysis of {symbol}."
+
+    # Build context from data
+    context_parts = []
+
+    if data.get("profile"):
+        p = data["profile"]
+        context_parts.append(f"**Company:** {p.get('name')} ({symbol})\n"
+                             f"Industry: {p.get('finnhubIndustry')} | Country: {p.get('country')}\n"
+                             f"Market Cap: {p.get('marketCapitalization')}M | Exchange: {p.get('exchange')}")
+
+    if data.get("overview"):
+        ov = data["overview"]
+        context_parts.append(
+            f"**Key Metrics (Alpha Vantage):**\n"
+            f"P/E: {ov.get('PERatio')} | P/B: {ov.get('PriceToBookRatio')} | EPS: {ov.get('EPS')}\n"
+            f"Revenue TTM: {ov.get('RevenueTTM')} | Profit Margin: {ov.get('ProfitMargin')}\n"
+            f"52W High: {ov.get('52WeekHigh')} | 52W Low: {ov.get('52WeekLow')}\n"
+            f"Dividend Yield: {ov.get('DividendYield')} | Beta: {ov.get('Beta')}\n"
+            f"Analyst Target: {ov.get('AnalystTargetPrice')}"
+        )
+
+    if data.get("metrics") and data["metrics"].get("metric"):
+        m = data["metrics"]["metric"]
+        selected = {
+            k: m[k] for k in [
+                "peNormalizedAnnual", "pbAnnual", "psAnnual", "roeAnnual",
+                "roaAnnual", "debtEquityAnnual", "currentRatioAnnual",
+                "revenueGrowth3Y", "epsGrowth3Y", "netMarginAnnual"
+            ] if k in m
+        }
+        context_parts.append(f"**Finnhub Metrics:**\n{json.dumps(selected, indent=2)}")
+
+    if data.get("earnings") and isinstance(data["earnings"], list):
+        recent = data["earnings"][:4]
+        lines = [f"{e.get('period')}: EPS actual={e.get('actual')} estimate={e.get('estimate')} surprise={e.get('surprise')}" for e in recent]
+        context_parts.append("**Earnings History (last 4Q):**\n" + "\n".join(lines))
+
+    if data.get("sentiment"):
+        s = data["sentiment"]
+        context_parts.append(
+            f"**News Sentiment:**\n"
+            f"Buzz score: {s.get('buzz', {}).get('buzz')}\n"
+            f"Sentiment score: {s.get('sentiment', {}).get('bearishPercent')} bear / {s.get('sentiment', {}).get('bullishPercent')} bull"
+        )
+
+    if data.get("news"):
+        headlines = [n.get("headline", "") for n in data["news"][:5]]
+        context_parts.append("**Recent Headlines:**\n" + "\n".join(f"• {h}" for h in headlines))
+
+    context = "\n\n".join(context_parts)
+
+    prompt = f"""## Data for {symbol}
+
+{context}
+
+---
+
+{question}
+
+Structure your response as:
+1. **Summary** (2-3 sentences)
+2. **Bull Case** (3 bullet points)
+3. **Bear Case** (3 bullet points)
+4. **Key Metrics Assessment**
+5. **Verdict** (Buy / Hold / Sell with brief rationale)"""
+
+    loop = __import__("asyncio").get_event_loop()
+
+    def _call():
+        msg = _client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1500,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        return msg.content[0].text
+
+    text = await loop.run_in_executor(None, _call)
+    return {"symbol": symbol, "analysis": text, "question": question}
+
+
+async def analyze_macro(macro_data: dict, question: str = "") -> dict:
+    """Interprets macro indicators."""
+    import asyncio
+
+    q = question or "What does the current macro environment mean for equity markets? What sectors/assets should investors favor?"
+
+    lines = []
+    for name, series in macro_data.items():
+        if series and series.get("observations"):
+            obs = series["observations"]
+            latest = obs[-1]
+            prev = obs[-2] if len(obs) > 1 else None
+            trend = ""
+            if prev:
+                try:
+                    diff = float(latest["value"]) - float(prev["value"])
+                    trend = f" (Δ{diff:+.2f})"
+                except Exception:
+                    pass
+            lines.append(f"**{name.upper()}**: {latest['value']}{trend} (as of {latest['date']})")
+
+    context = "\n".join(lines)
+
+    prompt = f"""## Current Macro Data
+
+{context}
+
+---
+
+{q}"""
+
+    loop = asyncio.get_event_loop()
+
+    def _call():
+        msg = _client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1000,
+            system=SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        return msg.content[0].text
+
+    text = await loop.run_in_executor(None, _call)
+    return {"analysis": text, "question": q}
+
+
+async def chat_analyst(messages: list, context_data: dict = None) -> str:
+    """
+    Free-form chat with the analyst.
+    messages: [{"role": "user"|"assistant", "content": "..."}]
+    """
+    import asyncio
+
+    system = SYSTEM_PROMPT
+    if context_data:
+        system += f"\n\nAvailable context data:\n{json.dumps(context_data, default=str)[:3000]}"
+
+    loop = asyncio.get_event_loop()
+
+    def _call():
+        msg = _client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=1000,
+            system=system,
+            messages=messages
+        )
+        return msg.content[0].text
+
+    return await loop.run_in_executor(None, _call)

--- a/trade-terminal/backend/services/bot_manager.py
+++ b/trade-terminal/backend/services/bot_manager.py
@@ -1,0 +1,206 @@
+import asyncio
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+import aiosqlite
+from config import BOTS_DIR, BOT_LOGS_DIR, BOT_CONFIGS_DIR, DB_PATH
+
+BOT_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+BOT_CONFIGS_DIR.mkdir(parents=True, exist_ok=True)
+Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
+
+# In-memory process registry: bot_id -> subprocess.Popen
+_processes: Dict[str, subprocess.Popen] = {}
+
+
+async def init_db():
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS bots (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                script_path TEXT NOT NULL,
+                description TEXT DEFAULT '',
+                created_at TEXT NOT NULL,
+                last_started TEXT,
+                last_stopped TEXT
+            )
+        """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS bot_configs (
+                bot_id TEXT NOT NULL,
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (bot_id, key)
+            )
+        """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS bot_logs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bot_id TEXT NOT NULL,
+                level TEXT NOT NULL,
+                message TEXT NOT NULL,
+                ts TEXT NOT NULL
+            )
+        """)
+        await db.commit()
+
+
+async def register_bot(bot_id: str, name: str, script_path: str, description: str = "") -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO bots (id, name, script_path, description, created_at) VALUES (?,?,?,?,?)",
+            (bot_id, name, script_path, description, datetime.utcnow().isoformat())
+        )
+        await db.commit()
+    return await get_bot(bot_id)
+
+
+async def get_bot(bot_id: str) -> Optional[dict]:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM bots WHERE id=?", (bot_id,)) as cur:
+            row = await cur.fetchone()
+            if not row:
+                return None
+            bot = dict(row)
+            bot["status"] = "running" if _is_running(bot_id) else "stopped"
+            bot["config"] = await _get_config(db, bot_id)
+            return bot
+
+
+async def list_bots() -> list:
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM bots ORDER BY name") as cur:
+            rows = await cur.fetchall()
+            result = []
+            for row in rows:
+                bot = dict(row)
+                bot["status"] = "running" if _is_running(bot["id"]) else "stopped"
+                bot["config"] = await _get_config(db, bot["id"])
+                result.append(bot)
+            return result
+
+
+async def start_bot(bot_id: str) -> dict:
+    bot = await get_bot(bot_id)
+    if not bot:
+        raise ValueError(f"Bot not found: {bot_id}")
+    if _is_running(bot_id):
+        raise RuntimeError("Bot already running")
+
+    script = Path(bot["script_path"])
+    if not script.exists():
+        raise FileNotFoundError(f"Script not found: {script}")
+
+    log_file = BOT_LOGS_DIR / f"{bot_id}.log"
+    config = bot.get("config", {})
+
+    # Pass config as env vars prefixed with BOT_
+    env = {f"BOT_{k.upper()}": str(v) for k, v in config.items()}
+
+    with open(log_file, "a") as lf:
+        proc = subprocess.Popen(
+            [sys.executable, str(script)],
+            stdout=lf,
+            stderr=lf,
+            env={**_current_env(), **env},
+            cwd=str(script.parent),
+        )
+    _processes[bot_id] = proc
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE bots SET last_started=? WHERE id=?",
+            (datetime.utcnow().isoformat(), bot_id)
+        )
+        await db.commit()
+
+    await _log(bot_id, "INFO", f"Bot started (pid={proc.pid})")
+    return await get_bot(bot_id)
+
+
+async def stop_bot(bot_id: str) -> dict:
+    if not _is_running(bot_id):
+        raise RuntimeError("Bot not running")
+    proc = _processes[bot_id]
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    del _processes[bot_id]
+
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE bots SET last_stopped=? WHERE id=?",
+            (datetime.utcnow().isoformat(), bot_id)
+        )
+        await db.commit()
+
+    await _log(bot_id, "INFO", "Bot stopped")
+    return await get_bot(bot_id)
+
+
+async def update_config(bot_id: str, config: dict) -> dict:
+    async with aiosqlite.connect(DB_PATH) as db:
+        for k, v in config.items():
+            await db.execute(
+                "INSERT OR REPLACE INTO bot_configs (bot_id, key, value) VALUES (?,?,?)",
+                (bot_id, k, json.dumps(v))
+            )
+        await db.commit()
+    return await get_bot(bot_id)
+
+
+async def get_logs(bot_id: str, lines: int = 100) -> list:
+    log_file = BOT_LOGS_DIR / f"{bot_id}.log"
+    if not log_file.exists():
+        return []
+    with open(log_file, "r", encoding="utf-8", errors="replace") as f:
+        all_lines = f.readlines()
+    return [l.rstrip() for l in all_lines[-lines:]]
+
+
+async def delete_bot(bot_id: str):
+    if _is_running(bot_id):
+        await stop_bot(bot_id)
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM bots WHERE id=?", (bot_id,))
+        await db.execute("DELETE FROM bot_configs WHERE bot_id=?", (bot_id,))
+        await db.commit()
+
+
+# --- helpers ---
+
+def _is_running(bot_id: str) -> bool:
+    proc = _processes.get(bot_id)
+    if not proc:
+        return False
+    return proc.poll() is None
+
+
+async def _get_config(db: aiosqlite.Connection, bot_id: str) -> dict:
+    async with db.execute(
+        "SELECT key, value FROM bot_configs WHERE bot_id=?", (bot_id,)
+    ) as cur:
+        rows = await cur.fetchall()
+        return {r[0]: json.loads(r[1]) for r in rows}
+
+
+async def _log(bot_id: str, level: str, message: str):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO bot_logs (bot_id, level, message, ts) VALUES (?,?,?,?)",
+            (bot_id, level, message, datetime.utcnow().isoformat())
+        )
+        await db.commit()
+
+
+def _current_env() -> dict:
+    import os
+    return dict(os.environ)

--- a/trade-terminal/backend/services/fundamental_data.py
+++ b/trade-terminal/backend/services/fundamental_data.py
@@ -1,0 +1,253 @@
+"""
+Fundamental analysis data.
+Sources: Finnhub (free) + SEC EDGAR (official, free) + FRED (macro, free) + Alpha Vantage (free tier)
+"""
+import httpx
+from typing import Optional
+from config import FINNHUB_API_KEY, ALPHA_VANTAGE_API_KEY, FRED_API_KEY
+
+_client = httpx.AsyncClient(timeout=20)
+
+
+# ── Finnhub Fundamentals ──────────────────────────────────────────────────────
+
+async def get_company_profile(symbol: str) -> Optional[dict]:
+    if not FINNHUB_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/stock/profile2",
+            params={"symbol": symbol, "token": FINNHUB_API_KEY}
+        )
+        d = r.json()
+        return d if d.get("name") else None
+    except Exception:
+        return None
+
+
+async def get_basic_financials(symbol: str) -> Optional[dict]:
+    if not FINNHUB_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/stock/metric",
+            params={"symbol": symbol, "metric": "all", "token": FINNHUB_API_KEY}
+        )
+        return r.json()
+    except Exception:
+        return None
+
+
+async def get_earnings(symbol: str) -> Optional[list]:
+    if not FINNHUB_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/stock/earnings",
+            params={"symbol": symbol, "token": FINNHUB_API_KEY}
+        )
+        return r.json()
+    except Exception:
+        return None
+
+
+async def get_news_sentiment(symbol: str, days: int = 7) -> Optional[dict]:
+    if not FINNHUB_API_KEY:
+        return None
+    from datetime import datetime, timedelta
+    to = datetime.utcnow().strftime("%Y-%m-%d")
+    frm = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%d")
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/news-sentiment",
+            params={"symbol": symbol, "token": FINNHUB_API_KEY}
+        )
+        return r.json()
+    except Exception:
+        return None
+
+
+async def get_company_news(symbol: str, days: int = 7) -> list:
+    if not FINNHUB_API_KEY:
+        return []
+    from datetime import datetime, timedelta
+    to = datetime.utcnow().strftime("%Y-%m-%d")
+    frm = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%d")
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/company-news",
+            params={"symbol": symbol, "from": frm, "to": to, "token": FINNHUB_API_KEY}
+        )
+        news = r.json()
+        return news[:20] if isinstance(news, list) else []
+    except Exception:
+        return []
+
+
+async def get_peers(symbol: str) -> list:
+    if not FINNHUB_API_KEY:
+        return []
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/stock/peers",
+            params={"symbol": symbol, "token": FINNHUB_API_KEY}
+        )
+        return r.json() if isinstance(r.json(), list) else []
+    except Exception:
+        return []
+
+
+# ── SEC EDGAR (official US gov API, completely free) ─────────────────────────
+
+async def get_sec_filings(ticker: str, form_type: str = "10-K", count: int = 5) -> list:
+    """Get recent SEC filings for a US company."""
+    try:
+        # First get CIK from ticker
+        r = await _client.get(
+            "https://efts.sec.gov/LATEST/search-index?q=%22{}%22&dateRange=custom&startdt=2020-01-01&forms={}".format(
+                ticker, form_type
+            ),
+            headers={"User-Agent": "TradeTerminal personal@example.com"}
+        )
+        # Use company search endpoint
+        r2 = await _client.get(
+            f"https://efts.sec.gov/LATEST/search-index?q=%22{ticker}%22&forms={form_type}",
+            headers={"User-Agent": "TradeTerminal personal@example.com"}
+        )
+        data = r2.json()
+        hits = data.get("hits", {}).get("hits", [])
+        return [
+            {
+                "form": h["_source"].get("form_type"),
+                "filed": h["_source"].get("file_date"),
+                "description": h["_source"].get("display_names", [{}])[0].get("name", ""),
+                "url": f"https://www.sec.gov/Archives/edgar/data/{h['_source'].get('entity_id')}/{h['_source'].get('file_num', '')}",
+            }
+            for h in hits[:count]
+        ]
+    except Exception:
+        return []
+
+
+# ── FRED Macro Data (Federal Reserve, completely free) ────────────────────────
+
+FRED_SERIES = {
+    "gdp": "GDP",
+    "inflation": "CPIAUCSL",
+    "unemployment": "UNRATE",
+    "fed_rate": "FEDFUNDS",
+    "10y_yield": "DGS10",
+    "2y_yield": "DGS2",
+    "vix": "VIXCLS",
+    "sp500": "SP500",
+    "dollar_index": "DTWEXBGS",
+    "oil_wti": "DCOILWTICO",
+}
+
+
+async def get_fred_series(series_id: str, limit: int = 12) -> Optional[dict]:
+    if not FRED_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://api.stlouisfed.org/fred/series/observations",
+            params={
+                "series_id": series_id,
+                "api_key": FRED_API_KEY,
+                "file_type": "json",
+                "sort_order": "desc",
+                "limit": limit,
+            }
+        )
+        data = r.json()
+        obs = data.get("observations", [])
+        return {
+            "series_id": series_id,
+            "observations": [
+                {"date": o["date"], "value": o["value"]}
+                for o in reversed(obs)
+                if o["value"] != "."
+            ]
+        }
+    except Exception:
+        return None
+
+
+async def get_macro_snapshot() -> dict:
+    """Get key macro indicators in one call."""
+    if not FRED_API_KEY:
+        return {"error": "FRED_API_KEY not set"}
+
+    import asyncio
+    tasks = {
+        name: get_fred_series(series_id, limit=3)
+        for name, series_id in FRED_SERIES.items()
+    }
+    results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+    return {
+        name: (r if not isinstance(r, Exception) else None)
+        for name, r in zip(tasks.keys(), results)
+    }
+
+
+# ── Alpha Vantage Income/Balance Sheet ───────────────────────────────────────
+
+async def get_income_statement(symbol: str) -> Optional[dict]:
+    if not ALPHA_VANTAGE_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://www.alphavantage.co/query",
+            params={
+                "function": "INCOME_STATEMENT",
+                "symbol": symbol,
+                "apikey": ALPHA_VANTAGE_API_KEY,
+            }
+        )
+        data = r.json()
+        reports = data.get("annualReports", [])[:4]
+        return {"symbol": symbol, "annual_reports": reports}
+    except Exception:
+        return None
+
+
+async def get_overview(symbol: str) -> Optional[dict]:
+    if not ALPHA_VANTAGE_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://www.alphavantage.co/query",
+            params={
+                "function": "OVERVIEW",
+                "symbol": symbol,
+                "apikey": ALPHA_VANTAGE_API_KEY,
+            }
+        )
+        data = r.json()
+        return data if data.get("Symbol") else None
+    except Exception:
+        return None
+
+
+# ── Unified fundamental bundle ────────────────────────────────────────────────
+
+async def get_full_fundamental(symbol: str) -> dict:
+    import asyncio
+    profile, metrics, earnings, sentiment, news, overview = await asyncio.gather(
+        get_company_profile(symbol),
+        get_basic_financials(symbol),
+        get_earnings(symbol),
+        get_news_sentiment(symbol),
+        get_company_news(symbol, days=3),
+        get_overview(symbol),
+        return_exceptions=True
+    )
+    return {
+        "symbol": symbol,
+        "profile": profile if not isinstance(profile, Exception) else None,
+        "metrics": metrics if not isinstance(metrics, Exception) else None,
+        "earnings": earnings if not isinstance(earnings, Exception) else None,
+        "sentiment": sentiment if not isinstance(sentiment, Exception) else None,
+        "news": news if not isinstance(news, Exception) else [],
+        "overview": overview if not isinstance(overview, Exception) else None,
+    }

--- a/trade-terminal/backend/services/market_data.py
+++ b/trade-terminal/backend/services/market_data.py
@@ -1,0 +1,268 @@
+"""
+Market data aggregator.
+Priority: Twelve Data (stocks/crypto/forex) → Finnhub (US equities) → Binance (crypto) → yfinance (fallback)
+All APIs are free tier, personal use legal.
+"""
+import asyncio
+import httpx
+from datetime import datetime, timedelta
+from typing import Optional
+from config import TWELVE_DATA_API_KEY, FINNHUB_API_KEY
+
+_client = httpx.AsyncClient(timeout=15)
+
+
+# ── Twelve Data ──────────────────────────────────────────────────────────────
+
+async def get_quote_twelve(symbol: str) -> Optional[dict]:
+    if not TWELVE_DATA_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://api.twelvedata.com/quote",
+            params={"symbol": symbol, "apikey": TWELVE_DATA_API_KEY}
+        )
+        data = r.json()
+        if data.get("status") == "error":
+            return None
+        return {
+            "symbol": symbol,
+            "price": float(data.get("close", 0)),
+            "open": float(data.get("open", 0)),
+            "high": float(data.get("high", 0)),
+            "low": float(data.get("low", 0)),
+            "volume": int(data.get("volume", 0)),
+            "change": float(data.get("change", 0)),
+            "change_pct": float(data.get("percent_change", 0)),
+            "name": data.get("name", symbol),
+            "exchange": data.get("exchange", ""),
+            "currency": data.get("currency", "USD"),
+            "source": "twelve_data",
+        }
+    except Exception:
+        return None
+
+
+async def get_ohlcv_twelve(
+    symbol: str,
+    interval: str = "1day",
+    outputsize: int = 90
+) -> Optional[list]:
+    """interval: 1min,5min,15min,30min,1h,2h,4h,1day,1week,1month"""
+    if not TWELVE_DATA_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://api.twelvedata.com/time_series",
+            params={
+                "symbol": symbol,
+                "interval": interval,
+                "outputsize": outputsize,
+                "apikey": TWELVE_DATA_API_KEY,
+            }
+        )
+        data = r.json()
+        if data.get("status") == "error":
+            return None
+        values = data.get("values", [])
+        return [
+            {
+                "time": v["datetime"],
+                "open": float(v["open"]),
+                "high": float(v["high"]),
+                "low": float(v["low"]),
+                "close": float(v["close"]),
+                "volume": int(v.get("volume", 0)),
+            }
+            for v in reversed(values)
+        ]
+    except Exception:
+        return None
+
+
+# ── Finnhub ───────────────────────────────────────────────────────────────────
+
+async def get_quote_finnhub(symbol: str) -> Optional[dict]:
+    if not FINNHUB_API_KEY:
+        return None
+    try:
+        r = await _client.get(
+            "https://finnhub.io/api/v1/quote",
+            params={"symbol": symbol, "token": FINNHUB_API_KEY}
+        )
+        d = r.json()
+        if not d.get("c"):
+            return None
+        return {
+            "symbol": symbol,
+            "price": d["c"],
+            "open": d["o"],
+            "high": d["h"],
+            "low": d["l"],
+            "prev_close": d["pc"],
+            "change": d["c"] - d["pc"],
+            "change_pct": ((d["c"] - d["pc"]) / d["pc"] * 100) if d["pc"] else 0,
+            "source": "finnhub",
+        }
+    except Exception:
+        return None
+
+
+# ── Binance (crypto, no key needed) ──────────────────────────────────────────
+
+async def get_quote_binance(symbol: str) -> Optional[dict]:
+    try:
+        r = await _client.get(
+            "https://api.binance.com/api/v3/ticker/24hr",
+            params={"symbol": symbol.upper()}
+        )
+        d = r.json()
+        if "code" in d:
+            return None
+        return {
+            "symbol": symbol,
+            "price": float(d["lastPrice"]),
+            "open": float(d["openPrice"]),
+            "high": float(d["highPrice"]),
+            "low": float(d["lowPrice"]),
+            "volume": float(d["volume"]),
+            "change": float(d["priceChange"]),
+            "change_pct": float(d["priceChangePercent"]),
+            "source": "binance",
+        }
+    except Exception:
+        return None
+
+
+async def get_ohlcv_binance(
+    symbol: str,
+    interval: str = "1d",
+    limit: int = 90
+) -> Optional[list]:
+    """interval: 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M"""
+    try:
+        r = await _client.get(
+            "https://api.binance.com/api/v3/klines",
+            params={"symbol": symbol.upper(), "interval": interval, "limit": limit}
+        )
+        rows = r.json()
+        if not isinstance(rows, list):
+            return None
+        return [
+            {
+                "time": datetime.utcfromtimestamp(row[0] / 1000).strftime("%Y-%m-%d %H:%M:%S"),
+                "open": float(row[1]),
+                "high": float(row[2]),
+                "low": float(row[3]),
+                "close": float(row[4]),
+                "volume": float(row[5]),
+            }
+            for row in rows
+        ]
+    except Exception:
+        return None
+
+
+# ── yfinance fallback ─────────────────────────────────────────────────────────
+
+async def get_quote_yfinance(symbol: str) -> Optional[dict]:
+    try:
+        import yfinance as yf
+        loop = asyncio.get_event_loop()
+        ticker = await loop.run_in_executor(None, lambda: yf.Ticker(symbol))
+        info = await loop.run_in_executor(None, lambda: ticker.fast_info)
+        price = getattr(info, "last_price", None) or getattr(info, "regularMarketPrice", None)
+        if not price:
+            return None
+        return {
+            "symbol": symbol,
+            "price": float(price),
+            "source": "yfinance",
+        }
+    except Exception:
+        return None
+
+
+# ── Unified API ───────────────────────────────────────────────────────────────
+
+_CRYPTO_PAIRS = {"BTCUSDT", "ETHUSDT", "BNBUSDT", "SOLUSDT", "XRPUSDT", "ADAUSDT", "DOGEUSDT"}
+
+def _is_crypto_binance(symbol: str) -> bool:
+    s = symbol.upper()
+    return s in _CRYPTO_PAIRS or s.endswith("USDT") or s.endswith("BTC")
+
+
+async def get_quote(symbol: str) -> dict:
+    if _is_crypto_binance(symbol):
+        result = await get_quote_binance(symbol)
+        if result:
+            return result
+
+    result = await get_quote_twelve(symbol)
+    if result:
+        return result
+
+    result = await get_quote_finnhub(symbol)
+    if result:
+        return result
+
+    result = await get_quote_yfinance(symbol)
+    if result:
+        return result
+
+    return {"symbol": symbol, "error": "No data found", "price": None}
+
+
+async def get_ohlcv(symbol: str, interval: str = "1day", limit: int = 90) -> list:
+    if _is_crypto_binance(symbol):
+        # Map interval to Binance format
+        mapping = {"1day": "1d", "1h": "1h", "4h": "4h", "15min": "15m", "5min": "5m", "1week": "1w"}
+        bi = mapping.get(interval, "1d")
+        result = await get_ohlcv_binance(symbol, bi, limit)
+        if result:
+            return result
+
+    result = await get_ohlcv_twelve(symbol, interval, limit)
+    if result:
+        return result
+
+    return []
+
+
+async def search_symbols(query: str) -> list:
+    results = []
+
+    if TWELVE_DATA_API_KEY:
+        try:
+            r = await _client.get(
+                "https://api.twelvedata.com/symbol_search",
+                params={"symbol": query, "apikey": TWELVE_DATA_API_KEY}
+            )
+            data = r.json()
+            for item in data.get("data", [])[:10]:
+                results.append({
+                    "symbol": item.get("symbol"),
+                    "name": item.get("instrument_name"),
+                    "exchange": item.get("exchange"),
+                    "type": item.get("instrument_type"),
+                })
+        except Exception:
+            pass
+
+    if FINNHUB_API_KEY and len(results) < 5:
+        try:
+            r = await _client.get(
+                "https://finnhub.io/api/v1/search",
+                params={"q": query, "token": FINNHUB_API_KEY}
+            )
+            for item in r.json().get("result", [])[:5]:
+                results.append({
+                    "symbol": item.get("symbol"),
+                    "name": item.get("description"),
+                    "exchange": item.get("primaryExchange"),
+                    "type": item.get("type"),
+                })
+        except Exception:
+            pass
+
+    return results

--- a/trade-terminal/backend/ws/live_feed.py
+++ b/trade-terminal/backend/ws/live_feed.py
@@ -1,0 +1,82 @@
+"""
+WebSocket live price feed.
+Clients subscribe to symbols; server polls market data every N seconds and pushes updates.
+"""
+import asyncio
+import json
+from collections import defaultdict
+from fastapi import WebSocket, WebSocketDisconnect
+from services.market_data import get_quote
+
+# symbol -> set of websockets
+_subscribers: dict[str, set[WebSocket]] = defaultdict(set)
+_all_sockets: set[WebSocket] = set()
+_poll_task: asyncio.Task | None = None
+
+
+async def handle_connection(ws: WebSocket):
+    await ws.accept()
+    _all_sockets.add(ws)
+    subscribed: set[str] = set()
+
+    try:
+        while True:
+            raw = await ws.receive_text()
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            action = msg.get("action")
+            symbol = str(msg.get("symbol", "")).upper()
+
+            if action == "subscribe" and symbol:
+                subscribed.add(symbol)
+                _subscribers[symbol].add(ws)
+                # Send immediately
+                quote = await get_quote(symbol)
+                await ws.send_json({"type": "quote", "data": quote})
+
+            elif action == "unsubscribe" and symbol:
+                subscribed.discard(symbol)
+                _subscribers[symbol].discard(ws)
+
+            elif action == "ping":
+                await ws.send_json({"type": "pong"})
+
+    except WebSocketDisconnect:
+        pass
+    finally:
+        _all_sockets.discard(ws)
+        for sym in subscribed:
+            _subscribers[sym].discard(ws)
+
+
+async def start_price_poller(interval: int = 5):
+    """Background task: poll all subscribed symbols every `interval` seconds."""
+    global _poll_task
+
+    async def _loop():
+        while True:
+            await asyncio.sleep(interval)
+            active_symbols = [s for s, sockets in _subscribers.items() if sockets]
+            if not active_symbols:
+                continue
+            quotes = await asyncio.gather(
+                *[get_quote(s) for s in active_symbols],
+                return_exceptions=True
+            )
+            for symbol, quote in zip(active_symbols, quotes):
+                if isinstance(quote, Exception):
+                    continue
+                dead = set()
+                for ws in list(_subscribers[symbol]):
+                    try:
+                        await ws.send_json({"type": "quote", "data": quote})
+                    except Exception:
+                        dead.add(ws)
+                for ws in dead:
+                    _subscribers[symbol].discard(ws)
+                    _all_sockets.discard(ws)
+
+    _poll_task = asyncio.create_task(_loop())

--- a/trade-terminal/frontend/.env.local.example
+++ b/trade-terminal/frontend/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_WS_URL=ws://localhost:8000

--- a/trade-terminal/frontend/next.config.js
+++ b/trade-terminal/frontend/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
+    NEXT_PUBLIC_WS_URL: process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8000",
+  },
+};
+
+module.exports = nextConfig;

--- a/trade-terminal/frontend/package.json
+++ b/trade-terminal/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "trade-terminal-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "export": "next build && next export"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "^18",
+    "react-dom": "^18",
+    "lightweight-charts": "^4.1.3",
+    "lucide-react": "^0.378.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.3.0",
+    "react-markdown": "^9.0.1",
+    "recharts": "^2.12.7",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "tailwindcss": "^3.4.3",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38"
+  }
+}

--- a/trade-terminal/frontend/postcss.config.js
+++ b/trade-terminal/frontend/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/trade-terminal/frontend/src/app/analysis/page.tsx
+++ b/trade-terminal/frontend/src/app/analysis/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { analysis as analysisApi } from "@/lib/api";
+import ReactMarkdown from "react-markdown";
+import { BrainCircuit, Globe, Send, RefreshCw, ChevronDown } from "lucide-react";
+
+type Tab = "fundamental" | "macro" | "chat";
+
+export default function AnalysisPage() {
+  const [tab, setTab] = useState<Tab>("fundamental");
+
+  // Fundamental
+  const [fundSymbol, setFundSymbol] = useState("AAPL");
+  const [fundQuestion, setFundQuestion] = useState("");
+  const [fundResult, setFundResult] = useState<any>(null);
+  const [fundLoading, setFundLoading] = useState(false);
+
+  // Macro
+  const [macroQuestion, setMacroQuestion] = useState("");
+  const [macroResult, setMacroResult] = useState<any>(null);
+  const [macroLoading, setMacroLoading] = useState(false);
+
+  // Chat
+  const [chatSymbol, setChatSymbol] = useState("");
+  const [chatInput, setChatInput] = useState("");
+  const [chatMessages, setChatMessages] = useState<{ role: string; content: string }[]>([]);
+  const [chatLoading, setChatLoading] = useState(false);
+  const chatRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (chatRef.current) chatRef.current.scrollTop = chatRef.current.scrollHeight;
+  }, [chatMessages]);
+
+  const runFundamental = async () => {
+    if (!fundSymbol.trim()) return;
+    setFundLoading(true);
+    const res = await analysisApi.fundamental(fundSymbol.trim(), fundQuestion).catch((e) => ({ error: e.message }));
+    setFundResult(res);
+    setFundLoading(false);
+  };
+
+  const runMacro = async () => {
+    setMacroLoading(true);
+    const res = await analysisApi.macro(macroQuestion).catch((e) => ({ error: e.message }));
+    setMacroResult(res);
+    setMacroLoading(false);
+  };
+
+  const sendChat = async () => {
+    if (!chatInput.trim() || chatLoading) return;
+    const userMsg = { role: "user", content: chatInput.trim() };
+    const newMessages = [...chatMessages, userMsg];
+    setChatMessages(newMessages);
+    setChatInput("");
+    setChatLoading(true);
+    const res = await analysisApi
+      .chat(newMessages, chatSymbol || undefined)
+      .catch((e) => ({ reply: `Hata: ${e.message}` }));
+    setChatMessages([...newMessages, { role: "assistant", content: res.reply }]);
+    setChatLoading(false);
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 gap-4">
+      {/* Tabs */}
+      <div className="flex gap-1">
+        {(["fundamental", "macro", "chat"] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`btn ${tab === t ? "btn-blue" : "btn-ghost"}`}
+          >
+            {t === "fundamental" ? "Temel Analiz" : t === "macro" ? "Makro" : "AI Chat"}
+          </button>
+        ))}
+      </div>
+
+      {/* Fundamental */}
+      {tab === "fundamental" && (
+        <div className="flex gap-4 flex-1 min-h-0">
+          <div className="flex flex-col gap-3 w-72 shrink-0">
+            <div className="panel p-3 flex flex-col gap-3">
+              <div>
+                <label className="text-text-muted text-xs mb-1 block">Sembol</label>
+                <input
+                  type="text"
+                  value={fundSymbol}
+                  onChange={(e) => setFundSymbol(e.target.value.toUpperCase())}
+                  onKeyDown={(e) => e.key === "Enter" && runFundamental()}
+                  placeholder="AAPL"
+                  className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue"
+                />
+              </div>
+              <div>
+                <label className="text-text-muted text-xs mb-1 block">Soru (opsiyonel)</label>
+                <textarea
+                  value={fundQuestion}
+                  onChange={(e) => setFundQuestion(e.target.value)}
+                  placeholder="Bu hisse değerli mi? Büyüme potansiyeli nedir?"
+                  rows={3}
+                  className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue resize-none"
+                />
+              </div>
+              <button
+                className="btn btn-blue flex items-center justify-center gap-2"
+                onClick={runFundamental}
+                disabled={fundLoading}
+              >
+                {fundLoading ? <RefreshCw size={12} className="animate-spin" /> : <BrainCircuit size={12} />}
+                {fundLoading ? "Analiz ediliyor..." : "Analiz Et"}
+              </button>
+            </div>
+
+            {/* Raw metrics quick view */}
+            {fundResult?.raw_data?.metrics?.metric && (
+              <div className="panel p-3 overflow-y-auto">
+                <div className="text-text-secondary text-xs font-medium mb-2">Temel Metrikler</div>
+                {[
+                  ["P/E", "peNormalizedAnnual"],
+                  ["P/B", "pbAnnual"],
+                  ["ROE %", "roeAnnual"],
+                  ["ROA %", "roaAnnual"],
+                  ["Net Margin %", "netMarginAnnual"],
+                  ["D/E", "debtEquityAnnual"],
+                  ["Rev Growth 3Y", "revenueGrowth3Y"],
+                ].map(([label, key]) => {
+                  const val = fundResult.raw_data.metrics.metric[key];
+                  return val != null ? (
+                    <div key={key} className="flex justify-between py-0.5 border-b border-bg-border/30">
+                      <span className="text-text-muted text-xs">{label}</span>
+                      <span className="text-text-primary text-xs">{Number(val).toFixed(2)}</span>
+                    </div>
+                  ) : null;
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Analysis result */}
+          <div className="panel flex-1 overflow-y-auto p-4">
+            {!fundResult && !fundLoading && (
+              <div className="flex flex-col items-center justify-center h-full text-text-muted gap-2">
+                <BrainCircuit size={32} className="opacity-30" />
+                <span className="text-sm">Sembol girin ve "Analiz Et"e basın</span>
+              </div>
+            )}
+            {fundLoading && (
+              <div className="flex items-center gap-2 text-text-muted">
+                <RefreshCw size={14} className="animate-spin" />
+                <span className="text-sm">Claude analiz yapıyor...</span>
+              </div>
+            )}
+            {fundResult?.error && (
+              <div className="text-accent-red text-sm">{fundResult.error}</div>
+            )}
+            {fundResult?.analysis && (
+              <div className="prose prose-invert prose-sm max-w-none">
+                <ReactMarkdown
+                  components={{
+                    h1: ({ children }) => <h1 className="text-text-primary text-base font-semibold mb-2">{children}</h1>,
+                    h2: ({ children }) => <h2 className="text-text-primary text-sm font-semibold mb-1.5 mt-3">{children}</h2>,
+                    h3: ({ children }) => <h3 className="text-accent-blue text-xs font-semibold mb-1 mt-2">{children}</h3>,
+                    p: ({ children }) => <p className="text-text-secondary text-xs leading-5 mb-2">{children}</p>,
+                    li: ({ children }) => <li className="text-text-secondary text-xs leading-5">{children}</li>,
+                    ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-0.5">{children}</ul>,
+                    strong: ({ children }) => <strong className="text-text-primary font-medium">{children}</strong>,
+                    code: ({ children }) => <code className="text-accent-yellow bg-bg-tertiary px-1 rounded text-xs">{children}</code>,
+                  }}
+                >
+                  {fundResult.analysis}
+                </ReactMarkdown>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Macro */}
+      {tab === "macro" && (
+        <div className="flex gap-4 flex-1 min-h-0">
+          <div className="w-72 shrink-0 panel p-3 flex flex-col gap-3">
+            <div>
+              <label className="text-text-muted text-xs mb-1 block">Makro Soru (opsiyonel)</label>
+              <textarea
+                value={macroQuestion}
+                onChange={(e) => setMacroQuestion(e.target.value)}
+                placeholder="Mevcut makro ortam hangi sektörler için fırsat sunuyor?"
+                rows={4}
+                className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue resize-none"
+              />
+            </div>
+            <button
+              className="btn btn-blue flex items-center justify-center gap-2"
+              onClick={runMacro}
+              disabled={macroLoading}
+            >
+              {macroLoading ? <RefreshCw size={12} className="animate-spin" /> : <Globe size={12} />}
+              {macroLoading ? "Analiz ediliyor..." : "Makro Analiz"}
+            </button>
+            <div className="text-text-muted text-xs mt-1">
+              Kaynak: FRED (Federal Reserve) — GDP, CPI, Fed Rate, 10Y Yield, VIX, DXY, WTI Oil
+            </div>
+          </div>
+
+          <div className="panel flex-1 overflow-y-auto p-4">
+            {!macroResult && !macroLoading && (
+              <div className="flex flex-col items-center justify-center h-full text-text-muted gap-2">
+                <Globe size={32} className="opacity-30" />
+                <span className="text-sm">"Makro Analiz"e basın</span>
+              </div>
+            )}
+            {macroLoading && (
+              <div className="flex items-center gap-2 text-text-muted">
+                <RefreshCw size={14} className="animate-spin" />
+                <span className="text-sm">FRED verileri çekiliyor ve analiz yapılıyor...</span>
+              </div>
+            )}
+            {macroResult?.error && <div className="text-accent-red text-sm">{macroResult.error}</div>}
+            {macroResult?.analysis && (
+              <div className="prose prose-invert prose-sm max-w-none">
+                <ReactMarkdown
+                  components={{
+                    h1: ({ n }) => <h1 className="text-text-primary text-base font-semibold mb-2">{n}</h1>,
+                    h2: ({ children }) => <h2 className="text-text-primary text-sm font-semibold mb-1.5 mt-3">{children}</h2>,
+                    h3: ({ children }) => <h3 className="text-accent-blue text-xs font-semibold mb-1 mt-2">{children}</h3>,
+                    p: ({ children }) => <p className="text-text-secondary text-xs leading-5 mb-2">{children}</p>,
+                    li: ({ children }) => <li className="text-text-secondary text-xs leading-5">{children}</li>,
+                    ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-0.5">{children}</ul>,
+                    strong: ({ children }) => <strong className="text-text-primary font-medium">{children}</strong>,
+                  }}
+                >
+                  {macroResult.analysis}
+                </ReactMarkdown>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Chat */}
+      {tab === "chat" && (
+        <div className="flex flex-col flex-1 panel overflow-hidden min-h-0">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-bg-border">
+            <input
+              type="text"
+              value={chatSymbol}
+              onChange={(e) => setChatSymbol(e.target.value.toUpperCase())}
+              placeholder="Sembol bağlamı (opsiyonel, AAPL)"
+              className="px-2 py-1 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue w-48"
+            />
+            <span className="text-text-muted text-xs">Senior equity analyst ile konuş</span>
+          </div>
+
+          <div ref={chatRef} className="flex-1 overflow-y-auto p-3 space-y-3">
+            {chatMessages.length === 0 && (
+              <div className="text-text-muted text-xs text-center py-8">
+                Analize başlamak için bir soru yazın. Türkçe veya İngilizce.
+              </div>
+            )}
+            {chatMessages.map((msg, i) => (
+              <div key={i} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+                <div
+                  className={`max-w-2xl rounded px-3 py-2 text-xs leading-5 ${
+                    msg.role === "user"
+                      ? "bg-accent-blue/20 text-text-primary ml-8"
+                      : "bg-bg-tertiary text-text-secondary mr-8"
+                  }`}
+                >
+                  {msg.role === "assistant" ? (
+                    <ReactMarkdown
+                      components={{
+                        p: ({ children }) => <p className="mb-1">{children}</p>,
+                        li: ({ children }) => <li>{children}</li>,
+                        strong: ({ children }) => <strong className="text-text-primary">{children}</strong>,
+                        code: ({ children }) => <code className="text-accent-yellow bg-bg-primary px-1 rounded">{children}</code>,
+                      }}
+                    >
+                      {msg.content}
+                    </ReactMarkdown>
+                  ) : (
+                    msg.content
+                  )}
+                </div>
+              </div>
+            ))}
+            {chatLoading && (
+              <div className="flex justify-start">
+                <div className="bg-bg-tertiary rounded px-3 py-2 text-xs text-text-muted flex items-center gap-2">
+                  <RefreshCw size={11} className="animate-spin" /> Düşünüyor...
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2 px-3 py-2 border-t border-bg-border">
+            <input
+              type="text"
+              value={chatInput}
+              onChange={(e) => setChatInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && sendChat()}
+              placeholder="Sorunuzu yazın... (Enter)"
+              className="flex-1 px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue"
+            />
+            <button
+              className="btn btn-blue flex items-center gap-1"
+              onClick={sendChat}
+              disabled={chatLoading || !chatInput.trim()}
+            >
+              <Send size={12} /> Gönder
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/trade-terminal/frontend/src/app/bots/page.tsx
+++ b/trade-terminal/frontend/src/app/bots/page.tsx
@@ -1,0 +1,257 @@
+"use client";
+import { useEffect, useState, useRef } from "react";
+import { bots as botApi } from "@/lib/api";
+import { Play, Square, Plus, Trash2, RefreshCw, Terminal, Settings2 } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+
+export default function BotsPage() {
+  const [botList, setBotList] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<any>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+  const [showRegister, setShowRegister] = useState(false);
+  const [showConfig, setShowConfig] = useState(false);
+  const [editConfig, setEditConfig] = useState("{}");
+  const [registerForm, setRegisterForm] = useState({ id: "", name: "", script_path: "", description: "" });
+  const logRef = useRef<HTMLDivElement>(null);
+
+  const refresh = async () => {
+    const list = await botApi.list().catch(() => []);
+    setBotList(list);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 5_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const selectBot = async (bot: any) => {
+    setSelected(bot);
+    setShowConfig(false);
+    const { logs: l } = await botApi.logs(bot.id, 200).catch(() => ({ logs: [] }));
+    setLogs(l);
+  };
+
+  useEffect(() => {
+    if (!selected) return;
+    const id = setInterval(async () => {
+      const { logs: l } = await botApi.logs(selected.id, 200).catch(() => ({ logs: [] }));
+      setLogs(l);
+    }, 3_000);
+    return () => clearInterval(id);
+  }, [selected]);
+
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [logs]);
+
+  const startBot = async (id: string) => {
+    await botApi.start(id).catch(alert);
+    refresh();
+  };
+
+  const stopBot = async (id: string) => {
+    await botApi.stop(id).catch(alert);
+    refresh();
+  };
+
+  const deleteBot = async (id: string) => {
+    if (!confirm(`"${id}" silinsin mi?`)) return;
+    await botApi.delete(id).catch(alert);
+    if (selected?.id === id) setSelected(null);
+    refresh();
+  };
+
+  const registerBot = async () => {
+    await botApi.register(registerForm).catch(alert);
+    setShowRegister(false);
+    setRegisterForm({ id: "", name: "", script_path: "", description: "" });
+    refresh();
+  };
+
+  const saveConfig = async () => {
+    try {
+      const cfg = JSON.parse(editConfig);
+      await botApi.updateConfig(selected.id, cfg);
+      setShowConfig(false);
+      refresh();
+    } catch {
+      alert("Geçersiz JSON");
+    }
+  };
+
+  return (
+    <div className="flex gap-4 h-full min-h-0">
+      {/* Bot list */}
+      <div className="w-64 shrink-0 panel flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-bg-border">
+          <span className="text-text-secondary text-xs font-medium">Botlar ({botList.length})</span>
+          <button className="btn btn-blue flex items-center gap-1" onClick={() => setShowRegister(true)}>
+            <Plus size={12} /> Ekle
+          </button>
+        </div>
+
+        <div className="overflow-y-auto flex-1">
+          {loading && <div className="text-text-muted text-xs p-3">Yükleniyor...</div>}
+          {!loading && botList.length === 0 && (
+            <div className="text-text-muted text-xs p-3">Henüz bot yok. "Ekle" ile kaydet.</div>
+          )}
+          {botList.map((bot) => (
+            <button
+              key={bot.id}
+              onClick={() => selectBot(bot)}
+              className={`w-full px-3 py-3 text-left hover:bg-bg-tertiary border-b border-bg-border/50 transition-colors ${
+                selected?.id === bot.id ? "bg-bg-tertiary" : ""
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-text-primary text-xs font-medium truncate">{bot.name}</span>
+                <span className={`tag ${bot.status === "running" ? "tag-green" : "tag-blue"}`}>
+                  {bot.status === "running" ? "●" : "○"}
+                </span>
+              </div>
+              <div className="text-text-muted text-xs mt-0.5 truncate">{bot.id}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      <div className="flex-1 flex flex-col gap-3 min-w-0">
+        {!selected ? (
+          <div className="panel flex-1 flex items-center justify-center">
+            <span className="text-text-muted text-sm">Bir bot seçin</span>
+          </div>
+        ) : (
+          <>
+            {/* Bot header */}
+            <div className="panel p-3 flex items-center gap-3 flex-wrap">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-text-primary font-medium">{selected.name}</span>
+                  <span className={`tag ${selected.status === "running" ? "tag-green" : "tag-blue"}`}>
+                    {selected.status}
+                  </span>
+                </div>
+                <div className="text-text-muted text-xs mt-0.5">{selected.script_path}</div>
+                {selected.description && (
+                  <div className="text-text-secondary text-xs mt-1">{selected.description}</div>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {selected.status !== "running" ? (
+                  <button className="btn btn-green flex items-center gap-1" onClick={() => startBot(selected.id)}>
+                    <Play size={12} /> Başlat
+                  </button>
+                ) : (
+                  <button className="btn btn-red flex items-center gap-1" onClick={() => stopBot(selected.id)}>
+                    <Square size={12} /> Durdur
+                  </button>
+                )}
+                <button
+                  className="btn btn-ghost flex items-center gap-1"
+                  onClick={() => {
+                    setEditConfig(JSON.stringify(selected.config || {}, null, 2));
+                    setShowConfig(!showConfig);
+                  }}
+                >
+                  <Settings2 size={12} /> Ayarlar
+                </button>
+                <button className="btn btn-ghost flex items-center gap-1 text-accent-red/70 hover:text-accent-red" onClick={() => deleteBot(selected.id)}>
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            </div>
+
+            {/* Config editor */}
+            {showConfig && (
+              <div className="panel p-3">
+                <div className="text-text-secondary text-xs mb-2 font-medium">Bot Parametreleri (JSON)</div>
+                <textarea
+                  value={editConfig}
+                  onChange={(e) => setEditConfig(e.target.value)}
+                  className="w-full h-32 bg-bg-primary border border-bg-border rounded p-2 text-xs font-mono text-text-primary focus:outline-none focus:border-accent-blue resize-y"
+                />
+                <div className="flex gap-2 mt-2">
+                  <button className="btn btn-blue" onClick={saveConfig}>Kaydet</button>
+                  <button className="btn btn-ghost" onClick={() => setShowConfig(false)}>İptal</button>
+                </div>
+                <div className="text-text-muted text-xs mt-2">
+                  Not: Parametreler bot'a <code>BOT_*</code> env vars olarak aktarılır.
+                </div>
+              </div>
+            )}
+
+            {/* Logs */}
+            <div className="panel flex-1 flex flex-col overflow-hidden" style={{ minHeight: 200 }}>
+              <div className="flex items-center justify-between px-3 py-2 border-b border-bg-border">
+                <span className="text-text-secondary text-xs font-medium flex items-center gap-1.5">
+                  <Terminal size={12} /> Log ({logs.length} satır)
+                </span>
+                <button
+                  onClick={async () => {
+                    const { logs: l } = await botApi.logs(selected.id, 500).catch(() => ({ logs: [] }));
+                    setLogs(l);
+                  }}
+                  className="text-text-muted hover:text-text-secondary"
+                >
+                  <RefreshCw size={12} />
+                </button>
+              </div>
+              <div
+                ref={logRef}
+                className="flex-1 overflow-y-auto p-3 font-mono text-xs text-text-secondary leading-5"
+              >
+                {logs.length === 0 ? (
+                  <span className="text-text-muted">Henüz log yok.</span>
+                ) : (
+                  logs.map((line, i) => (
+                    <div key={i} className={
+                      line.includes("ERROR") ? "text-accent-red" :
+                      line.includes("WARN") ? "text-accent-yellow" :
+                      line.includes("started") || line.includes("INFO") ? "text-accent-green" : ""
+                    }>
+                      {line || " "}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Register modal */}
+      {showRegister && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="panel p-5 w-96">
+            <h2 className="text-text-primary font-medium mb-4">Bot Kaydet</h2>
+            {[
+              { key: "id", label: "ID (benzersiz)", placeholder: "macd_bot" },
+              { key: "name", label: "İsim", placeholder: "MACD Stratejisi" },
+              { key: "script_path", label: "Script Yolu", placeholder: "C:/bots/macd_bot.py" },
+              { key: "description", label: "Açıklama (opsiyonel)", placeholder: "" },
+            ].map(({ key, label, placeholder }) => (
+              <div key={key} className="mb-3">
+                <label className="text-text-secondary text-xs mb-1 block">{label}</label>
+                <input
+                  type="text"
+                  value={(registerForm as any)[key]}
+                  onChange={(e) => setRegisterForm((f) => ({ ...f, [key]: e.target.value }))}
+                  placeholder={placeholder}
+                  className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue"
+                />
+              </div>
+            ))}
+            <div className="flex gap-2 mt-4">
+              <button className="btn btn-blue flex-1" onClick={registerBot}>Kaydet</button>
+              <button className="btn btn-ghost flex-1" onClick={() => setShowRegister(false)}>İptal</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/trade-terminal/frontend/src/app/globals.css
+++ b/trade-terminal/frontend/src/app/globals.css
@@ -1,0 +1,44 @@
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap');
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* { box-sizing: border-box; }
+
+body {
+  background-color: #0d1117;
+  color: #e6edf3;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+}
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: #0d1117; }
+::-webkit-scrollbar-thumb { background: #30363d; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #484f58; }
+
+.positive { color: #3fb950; }
+.negative { color: #f85149; }
+.neutral  { color: #8b949e; }
+
+.panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+}
+
+.btn {
+  @apply px-3 py-1.5 rounded text-xs font-medium transition-colors cursor-pointer border-0 outline-none;
+}
+.btn-green  { @apply bg-accent-green/20 text-accent-green hover:bg-accent-green/30; }
+.btn-red    { @apply bg-accent-red/20 text-accent-red hover:bg-accent-red/30; }
+.btn-blue   { @apply bg-accent-blue/20 text-accent-blue hover:bg-accent-blue/30; }
+.btn-ghost  { @apply bg-bg-tertiary text-text-secondary hover:bg-bg-border hover:text-text-primary; }
+
+.tag {
+  @apply inline-block px-2 py-0.5 rounded text-xs;
+}
+.tag-green  { @apply bg-accent-green/20 text-accent-green; }
+.tag-red    { @apply bg-accent-red/20 text-accent-red; }
+.tag-blue   { @apply bg-accent-blue/20 text-accent-blue; }
+.tag-yellow { @apply bg-accent-yellow/20 text-accent-yellow; }

--- a/trade-terminal/frontend/src/app/layout.tsx
+++ b/trade-terminal/frontend/src/app/layout.tsx
@@ -1,0 +1,22 @@
+"use client";
+import "./globals.css";
+import Sidebar from "@/components/layout/Sidebar";
+import Topbar from "@/components/layout/Topbar";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <title>Trade Terminal</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body className="flex h-screen overflow-hidden bg-bg-primary">
+        <Sidebar />
+        <div className="flex flex-col flex-1 min-w-0">
+          <Topbar />
+          <main className="flex-1 overflow-auto p-4">{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/trade-terminal/frontend/src/app/page.tsx
+++ b/trade-terminal/frontend/src/app/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import TradingViewWidget from "@/components/charts/TradingViewWidget";
+import QuoteTicker from "@/components/charts/QuoteTicker";
+import { market } from "@/lib/api";
+import { RefreshCw } from "lucide-react";
+
+const INTERVALS: { label: string; tv: string; api: string }[] = [
+  { label: "1m", tv: "1", api: "1min" },
+  { label: "5m", tv: "5", api: "5min" },
+  { label: "15m", tv: "15", api: "15min" },
+  { label: "1h", tv: "60", api: "1h" },
+  { label: "4h", tv: "240", api: "4h" },
+  { label: "1D", tv: "D", api: "1day" },
+  { label: "1W", tv: "W", api: "1week" },
+];
+
+const WATCHLIST_DEFAULT = ["AAPL", "MSFT", "BTCUSDT", "ETHUSDT", "NVDA", "TSLA"];
+
+export default function DashboardPage() {
+  const params = useSearchParams();
+  const [symbol, setSymbol] = useState(params.get("symbol") || "AAPL");
+  const [interval, setInterval] = useState(INTERVALS[5]);
+  const [watchlist, setWatchlist] = useState<any[]>([]);
+  const [loadingWL, setLoadingWL] = useState(true);
+
+  useEffect(() => {
+    const sym = params.get("symbol");
+    if (sym) setSymbol(sym.toUpperCase());
+  }, [params]);
+
+  const refreshWatchlist = async () => {
+    setLoadingWL(true);
+    const res = await market.quotes(WATCHLIST_DEFAULT).catch(() => ({}));
+    setWatchlist(Object.values(res));
+    setLoadingWL(false);
+  };
+
+  useEffect(() => {
+    refreshWatchlist();
+    const id = setInterval(refreshWatchlist, 15_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="flex gap-4 h-full min-h-0">
+      {/* Main chart area */}
+      <div className="flex-1 flex flex-col gap-3 min-w-0">
+        <div className="panel p-3">
+          <QuoteTicker symbol={symbol} />
+        </div>
+
+        <div className="panel p-0 overflow-hidden flex-1" style={{ minHeight: 480 }}>
+          {/* Interval selector */}
+          <div className="flex items-center gap-1 px-3 py-2 border-b border-bg-border">
+            {INTERVALS.map((iv) => (
+              <button
+                key={iv.tv}
+                onClick={() => setInterval(iv)}
+                className={`btn ${interval.tv === iv.tv ? "btn-blue" : "btn-ghost"}`}
+              >
+                {iv.label}
+              </button>
+            ))}
+            <div className="ml-auto text-xs text-text-muted">TradingView</div>
+          </div>
+          <TradingViewWidget symbol={symbol} interval={interval.tv} height={460} />
+        </div>
+      </div>
+
+      {/* Watchlist */}
+      <div className="w-56 shrink-0 flex flex-col panel overflow-hidden">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-bg-border">
+          <span className="text-text-secondary text-xs font-medium">Watchlist</span>
+          <button onClick={refreshWatchlist} className="text-text-muted hover:text-text-secondary">
+            <RefreshCw size={12} className={loadingWL ? "animate-spin" : ""} />
+          </button>
+        </div>
+        <div className="overflow-y-auto flex-1">
+          {watchlist.map((q) => {
+            if (!q?.symbol) return null;
+            const chg = q.change_pct ?? 0;
+            const isPos = chg >= 0;
+            return (
+              <button
+                key={q.symbol}
+                className={`w-full px-3 py-2.5 text-left hover:bg-bg-tertiary border-b border-bg-border/50 transition-colors ${
+                  symbol === q.symbol ? "bg-bg-tertiary" : ""
+                }`}
+                onClick={() => setSymbol(q.symbol)}
+              >
+                <div className="flex justify-between items-center">
+                  <span className="text-accent-blue text-xs font-medium">{q.symbol}</span>
+                  <span className={`text-xs ${isPos ? "positive" : "negative"}`}>
+                    {isPos ? "+" : ""}{chg.toFixed(2)}%
+                  </span>
+                </div>
+                <div className="text-text-primary text-xs mt-0.5">
+                  {q.price != null
+                    ? Number(q.price).toLocaleString(undefined, { maximumFractionDigits: 4 })
+                    : "—"}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/trade-terminal/frontend/src/app/settings/page.tsx
+++ b/trade-terminal/frontend/src/app/settings/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Save } from "lucide-react";
+
+interface Setting {
+  key: string;
+  label: string;
+  description: string;
+  type: "text" | "url";
+  env: string;
+}
+
+const SETTINGS: Setting[] = [
+  { key: "api_url", label: "Backend API URL", description: "FastAPI sunucusunun adresi", type: "url", env: "NEXT_PUBLIC_API_URL" },
+  { key: "ws_url", label: "WebSocket URL", description: "WebSocket bağlantı adresi", type: "url", env: "NEXT_PUBLIC_WS_URL" },
+];
+
+const API_KEYS: { label: string; key: string; url: string }[] = [
+  { label: "Anthropic API Key", key: "ANTHROPIC_API_KEY", url: "https://console.anthropic.com/" },
+  { label: "Finnhub API Key", key: "FINNHUB_API_KEY", url: "https://finnhub.io/register" },
+  { label: "Twelve Data API Key", key: "TWELVE_DATA_API_KEY", url: "https://twelvedata.com/register" },
+  { label: "Alpha Vantage API Key", key: "ALPHA_VANTAGE_API_KEY", url: "https://www.alphavantage.co/support/#api-key" },
+  { label: "FRED API Key", key: "FRED_API_KEY", url: "https://fred.stlouisfed.org/docs/api/api_key.html" },
+];
+
+export default function SettingsPage() {
+  const [apiUrl, setApiUrl] = useState(process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000");
+  const [wsUrl, setWsUrl] = useState(process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8000");
+  const [health, setHealth] = useState<"checking" | "ok" | "error">("checking");
+
+  const checkHealth = async () => {
+    setHealth("checking");
+    try {
+      const res = await fetch(`${apiUrl}/api/health`);
+      setHealth(res.ok ? "ok" : "error");
+    } catch {
+      setHealth("error");
+    }
+  };
+
+  useEffect(() => { checkHealth(); }, [apiUrl]);
+
+  return (
+    <div className="max-w-2xl flex flex-col gap-4">
+      <h1 className="text-text-primary font-medium text-sm">Ayarlar</h1>
+
+      {/* Backend connection */}
+      <div className="panel p-4">
+        <h2 className="text-text-secondary text-xs font-medium mb-3">Backend Bağlantısı</h2>
+
+        <div className="flex items-center gap-3 mb-3">
+          <span className={`tag ${health === "ok" ? "tag-green" : health === "error" ? "tag-red" : "tag-yellow"}`}>
+            {health === "ok" ? "● Bağlı" : health === "error" ? "● Bağlantı yok" : "● Kontrol ediliyor..."}
+          </span>
+          <button className="btn btn-ghost text-xs" onClick={checkHealth}>Tekrar dene</button>
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-text-muted text-xs mb-1 block">API URL</label>
+            <input
+              type="text"
+              value={apiUrl}
+              onChange={(e) => setApiUrl(e.target.value)}
+              className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue"
+            />
+          </div>
+          <div>
+            <label className="text-text-muted text-xs mb-1 block">WebSocket URL</label>
+            <input
+              type="text"
+              value={wsUrl}
+              onChange={(e) => setWsUrl(e.target.value)}
+              className="w-full px-2 py-1.5 bg-bg-primary border border-bg-border rounded text-xs text-text-primary focus:outline-none focus:border-accent-blue"
+            />
+          </div>
+        </div>
+        <p className="text-text-muted text-xs mt-3">
+          Bu değerleri değiştirmek için <code className="text-accent-yellow bg-bg-tertiary px-1 rounded">frontend/.env.local</code> dosyasını düzenleyin.
+        </p>
+      </div>
+
+      {/* API Keys guide */}
+      <div className="panel p-4">
+        <h2 className="text-text-secondary text-xs font-medium mb-3">API Key Kurulumu</h2>
+        <p className="text-text-muted text-xs mb-3">
+          API key'leri <code className="text-accent-yellow bg-bg-tertiary px-1 rounded">backend/.env</code> dosyasına ekleyin.
+        </p>
+        <div className="space-y-2">
+          {API_KEYS.map(({ label, key, url }) => (
+            <div key={key} className="flex items-center justify-between py-2 border-b border-bg-border/50">
+              <div>
+                <div className="text-text-primary text-xs">{label}</div>
+                <code className="text-text-muted text-xs">{key}</code>
+              </div>
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-ghost text-xs"
+              >
+                Ücretsiz al →
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Cloudflare tunnel */}
+      <div className="panel p-4">
+        <h2 className="text-text-secondary text-xs font-medium mb-2">Dışarıdan Erişim (Cloudflare Tunnel)</h2>
+        <p className="text-text-muted text-xs mb-3">
+          Evi dışından erişmek için Cloudflare Tunnel kullanın — ücretsiz, port forwarding gerektirmez.
+        </p>
+        <div className="bg-bg-primary border border-bg-border rounded p-3 font-mono text-xs text-text-secondary space-y-1">
+          <div className="text-text-muted"># Windows PowerShell</div>
+          <div>winget install cloudflare.cloudflared</div>
+          <div>cloudflared tunnel login</div>
+          <div>cloudflared tunnel create trade-terminal</div>
+          <div>cloudflared tunnel route dns trade-terminal terminal.senindomain.com</div>
+          <div>cloudflared tunnel run trade-terminal</div>
+        </div>
+        <p className="text-text-muted text-xs mt-2">
+          Alternatif: <code className="text-accent-yellow bg-bg-tertiary px-1 rounded">ngrok http 8000</code>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/trade-terminal/frontend/src/components/charts/QuoteTicker.tsx
+++ b/trade-terminal/frontend/src/components/charts/QuoteTicker.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useEffect, useState } from "react";
+import { createLiveFeed } from "@/lib/api";
+import { TrendingUp, TrendingDown } from "lucide-react";
+
+interface Props {
+  symbol: string;
+}
+
+export default function QuoteTicker({ symbol }: Props) {
+  const [quote, setQuote] = useState<any>(null);
+  const [flash, setFlash] = useState<"up" | "down" | null>(null);
+  const [prevPrice, setPrevPrice] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!symbol) return;
+    const feed = createLiveFeed();
+
+    feed.ws.addEventListener("open", () => feed.subscribe(symbol));
+    feed.onQuote((data) => {
+      if (data.symbol?.toUpperCase() !== symbol.toUpperCase()) return;
+      setQuote(data);
+      if (prevPrice !== null && data.price !== null) {
+        setFlash(data.price > prevPrice ? "up" : "down");
+        setTimeout(() => setFlash(null), 600);
+      }
+      setPrevPrice(data.price);
+    });
+
+    return () => feed.close();
+  }, [symbol]);
+
+  if (!quote) return (
+    <div className="flex items-center gap-2 text-text-muted animate-pulse">
+      <span className="text-sm">{symbol}</span>
+      <span className="text-xs">Yükleniyor...</span>
+    </div>
+  );
+
+  const chgPct = quote.change_pct ?? 0;
+  const isPos = chgPct >= 0;
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <span className="text-text-secondary text-sm font-medium">{symbol}</span>
+      <span
+        className={`text-xl font-semibold transition-colors duration-300 ${
+          flash === "up" ? "text-accent-green" : flash === "down" ? "text-accent-red" : "text-text-primary"
+        }`}
+      >
+        {quote.price != null ? Number(quote.price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 }) : "—"}
+      </span>
+      <span className={`flex items-center gap-1 text-sm ${isPos ? "positive" : "negative"}`}>
+        {isPos ? <TrendingUp size={14} /> : <TrendingDown size={14} />}
+        {isPos ? "+" : ""}{chgPct.toFixed(2)}%
+      </span>
+      {quote.high && (
+        <span className="text-xs text-text-muted">
+          H: {Number(quote.high).toLocaleString(undefined, { maximumFractionDigits: 4 })}
+          {" "}L: {Number(quote.low).toLocaleString(undefined, { maximumFractionDigits: 4 })}
+        </span>
+      )}
+      {quote.source && (
+        <span className="tag tag-blue ml-auto">{quote.source}</span>
+      )}
+    </div>
+  );
+}

--- a/trade-terminal/frontend/src/components/charts/TradingViewWidget.tsx
+++ b/trade-terminal/frontend/src/components/charts/TradingViewWidget.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface Props {
+  symbol: string;
+  interval?: string;
+  height?: number;
+}
+
+// Embeds the official TradingView Advanced Chart Widget (free, personal use)
+export default function TradingViewWidget({ symbol, interval = "D", height = 500 }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const scriptRef = useRef<HTMLScriptElement | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    ref.current.innerHTML = "";
+
+    const container = document.createElement("div");
+    container.className = "tradingview-widget-container__widget";
+    ref.current.appendChild(container);
+
+    const script = document.createElement("script");
+    script.src = "https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js";
+    script.type = "text/javascript";
+    script.async = true;
+    script.innerHTML = JSON.stringify({
+      autosize: true,
+      symbol: symbol,
+      interval: interval,
+      timezone: "Europe/Istanbul",
+      theme: "dark",
+      style: "1",
+      locale: "tr",
+      backgroundColor: "#161b22",
+      gridColor: "rgba(48,54,61,0.3)",
+      hide_top_toolbar: false,
+      hide_legend: false,
+      save_image: false,
+      calendar: false,
+      hide_volume: false,
+      support_host: "https://www.tradingview.com",
+    });
+
+    ref.current.appendChild(script);
+    scriptRef.current = script;
+
+    return () => {
+      if (ref.current) ref.current.innerHTML = "";
+    };
+  }, [symbol, interval]);
+
+  return (
+    <div
+      ref={ref}
+      className="tradingview-widget-container w-full"
+      style={{ height }}
+    />
+  );
+}

--- a/trade-terminal/frontend/src/components/layout/Sidebar.tsx
+++ b/trade-terminal/frontend/src/components/layout/Sidebar.tsx
@@ -1,0 +1,40 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BarChart2, Bot, BrainCircuit, Settings, TrendingUp } from "lucide-react";
+
+const NAV = [
+  { href: "/", icon: TrendingUp, label: "Dashboard" },
+  { href: "/bots", icon: Bot, label: "Bots" },
+  { href: "/analysis", icon: BrainCircuit, label: "AI Analiz" },
+  { href: "/settings", icon: Settings, label: "Ayarlar" },
+];
+
+export default function Sidebar() {
+  const path = usePathname();
+
+  return (
+    <aside className="w-14 flex flex-col items-center py-4 bg-bg-secondary border-r border-bg-border gap-1 shrink-0">
+      <div className="mb-4 text-accent-blue">
+        <BarChart2 size={22} />
+      </div>
+      {NAV.map(({ href, icon: Icon, label }) => {
+        const active = href === "/" ? path === "/" : path.startsWith(href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            title={label}
+            className={`w-10 h-10 flex items-center justify-center rounded-md transition-colors ${
+              active
+                ? "bg-accent-blue/20 text-accent-blue"
+                : "text-text-muted hover:text-text-secondary hover:bg-bg-tertiary"
+            }`}
+          >
+            <Icon size={18} />
+          </Link>
+        );
+      })}
+    </aside>
+  );
+}

--- a/trade-terminal/frontend/src/components/layout/Topbar.tsx
+++ b/trade-terminal/frontend/src/components/layout/Topbar.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { Search, Wifi, WifiOff } from "lucide-react";
+import { market } from "@/lib/api";
+import { useRouter } from "next/navigation";
+
+export default function Topbar() {
+  const [connected, setConnected] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<any[]>([]);
+  const router = useRouter();
+  const timer = useRef<any>(null);
+
+  useEffect(() => {
+    const check = async () => {
+      try {
+        await fetch(`${process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000"}/api/health`);
+        setConnected(true);
+      } catch {
+        setConnected(false);
+      }
+    };
+    check();
+    const id = setInterval(check, 10_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const handleSearch = (v: string) => {
+    setQuery(v);
+    clearTimeout(timer.current);
+    if (!v.trim()) { setResults([]); return; }
+    timer.current = setTimeout(async () => {
+      const res = await market.search(v).catch(() => []);
+      setResults(res.slice(0, 6));
+    }, 350);
+  };
+
+  return (
+    <header className="h-11 flex items-center px-4 bg-bg-secondary border-b border-bg-border gap-4 shrink-0">
+      {/* Search */}
+      <div className="relative flex-1 max-w-xs">
+        <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-muted" />
+        <input
+          type="text"
+          placeholder="Sembol ara... (AAPL, BTCUSDT)"
+          value={query}
+          onChange={(e) => handleSearch(e.target.value)}
+          className="w-full pl-7 pr-3 py-1.5 bg-bg-tertiary border border-bg-border rounded text-xs text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent-blue"
+        />
+        {results.length > 0 && (
+          <div className="absolute top-full mt-1 left-0 right-0 panel z-50 py-1">
+            {results.map((r, i) => (
+              <button
+                key={i}
+                className="w-full px-3 py-1.5 text-left hover:bg-bg-tertiary flex justify-between items-center"
+                onClick={() => {
+                  setQuery("");
+                  setResults([]);
+                  router.push(`/?symbol=${r.symbol}`);
+                }}
+              >
+                <span className="text-accent-blue font-medium">{r.symbol}</span>
+                <span className="text-text-muted truncate ml-2 text-xs">{r.name}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2 text-xs">
+        <span className={connected ? "text-accent-green" : "text-accent-red"}>
+          {connected ? <Wifi size={13} /> : <WifiOff size={13} />}
+        </span>
+        <span className={connected ? "text-accent-green" : "text-accent-red"}>
+          {connected ? "Bağlı" : "Bağlantı yok"}
+        </span>
+        <span className="text-text-muted">|</span>
+        <span className="text-text-muted">{new Date().toLocaleDateString("tr-TR")}</span>
+      </div>
+    </header>
+  );
+}

--- a/trade-terminal/frontend/tailwind.config.js
+++ b/trade-terminal/frontend/tailwind.config.js
@@ -1,0 +1,33 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        bg: {
+          primary: "#0d1117",
+          secondary: "#161b22",
+          tertiary: "#1c2128",
+          border: "#30363d",
+        },
+        accent: {
+          green: "#3fb950",
+          red: "#f85149",
+          blue: "#58a6ff",
+          yellow: "#d29922",
+          purple: "#bc8cff",
+          cyan: "#39d353",
+        },
+        text: {
+          primary: "#e6edf3",
+          secondary: "#8b949e",
+          muted: "#484f58",
+        },
+      },
+      fontFamily: {
+        mono: ["'JetBrains Mono'", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/trade-terminal/frontend/tsconfig.json
+++ b/trade-terminal/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/trade-terminal/setup.bat
+++ b/trade-terminal/setup.bat
@@ -1,0 +1,46 @@
+@echo off
+echo ===================================
+echo  Trade Terminal - Windows Kurulum
+echo ===================================
+echo.
+
+:: Backend
+echo [1/4] Backend Python ortami kuruluyor...
+cd backend
+python -m venv venv
+call venv\Scripts\activate
+pip install -r requirements.txt
+if not exist .env (
+    copy .env.example .env
+    echo  .env dosyasi olusturuldu. API key leri ekleyin: backend\.env
+)
+cd ..
+
+:: Frontend
+echo.
+echo [2/4] Frontend bagımliliklari yukleniyor...
+cd frontend
+call npm install
+if not exist .env.local (
+    echo NEXT_PUBLIC_API_URL=http://localhost:8000 > .env.local
+    echo NEXT_PUBLIC_WS_URL=ws://localhost:8000 >> .env.local
+    echo  .env.local olusturuldu.
+)
+cd ..
+
+echo.
+echo [3/4] Bot klasoru olusturuluyor...
+if not exist backend\bots mkdir backend\bots
+if not exist backend\logs\bots mkdir backend\logs\bots
+if not exist backend\configs\bots mkdir backend\configs\bots
+if not exist backend\data mkdir backend\data
+
+echo.
+echo ===================================
+echo  Kurulum tamamlandi!
+echo.
+echo  Sonraki adimlar:
+echo  1. backend\.env dosyasina API key lerini ekle
+echo  2. start.bat ile baslatabilirsin
+echo ===================================
+pause

--- a/trade-terminal/start.bat
+++ b/trade-terminal/start.bat
@@ -1,0 +1,16 @@
+@echo off
+echo Baslatiliyor...
+
+:: Backend
+start "Trade Terminal - Backend" cmd /k "cd /d %~dp0backend && venv\Scripts\activate && uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+
+:: Frontend
+timeout /t 2 /nobreak > nul
+start "Trade Terminal - Frontend" cmd /k "cd /d %~dp0frontend && npm run dev"
+
+echo.
+echo Backend:  http://localhost:8000
+echo Frontend: http://localhost:3000
+echo API Docs: http://localhost:8000/docs
+echo.
+echo Durdurmaniz icin acilan terminalleri kapatin.


### PR DESCRIPTION
## Summary

- Full-stack **personal trading terminal** designed to run on a home Windows PC as the server
- **Bot control panel**: register Python algo bots by script path, start/stop processes, live log streaming, JSON config editor (params passed as `BOT_*` env vars)
- **Live charts**: TradingView Advanced Chart widget (official embed, free personal use) with interval switcher and real-time watchlist via WebSocket
- **AI fundamental analysis**: Claude API interprets Finnhub metrics, SEC EDGAR filings, FRED macro data, Alpha Vantage financials — structured Bull/Bear/Verdict output
- **Macro dashboard**: FRED (Federal Reserve official API) — GDP, CPI, Fed Rate, 10Y Yield, VIX, DXY, WTI Oil — interpreted by Claude
- **Analyst chat**: free-form conversation with Claude acting as a senior equity analyst, Turkish/English

## Architecture

```
Windows PC (server)
├── FastAPI backend  (port 8000) — bots, market data, AI analysis, WebSocket live feed
└── Next.js frontend (port 3000) — TradingView charts, bot panel, analysis dashboard
```

External access via Cloudflare Tunnel (free, no port forwarding needed) — setup instructions in the Settings page.

## Legal data sources (all free tier)

| Source | Data | Notes |
|--------|------|-------|
| Binance Public API | Crypto OHLCV, quotes | No key needed |
| Twelve Data | Stocks / forex / crypto | 800 req/day free |
| Finnhub | US equities, fundamentals, news sentiment | Free tier |
| SEC EDGAR | Official US company filings | Completely free, official gov API |
| FRED (Federal Reserve) | Macro indicators | Completely free, official gov API |
| Alpha Vantage | Income statements, overview | 25 req/day free |

## Setup (Windows)

1. `setup.bat` — creates Python venv, installs deps, scaffolds dirs
2. Add API keys to `backend/.env` (template at `backend/.env.example`)
3. `start.bat` — launches backend + frontend in separate terminals

## Files changed

```
trade-terminal/
├── backend/
│   ├── main.py                     FastAPI app + WebSocket + lifespan
│   ├── config.py                   .env management
│   ├── requirements.txt
│   ├── routers/bots.py             Bot CRUD + start/stop/logs API
│   ├── routers/market.py           Quote / OHLCV / search
│   ├── routers/analysis.py         AI analysis endpoints
│   ├── services/bot_manager.py     Process management + SQLite logging
│   ├── services/market_data.py     Binance → TwelveData → Finnhub → yfinance fallback
│   ├── services/fundamental_data.py Finnhub / SEC EDGAR / FRED / Alpha Vantage
│   ├── services/ai_analyst.py      Claude API: fundamental, macro, chat
│   └── ws/live_feed.py             WebSocket price poller
└── frontend/
    ├── src/app/page.tsx             Dashboard + TradingView + watchlist
    ├── src/app/bots/page.tsx        Bot control panel
    ├── src/app/analysis/page.tsx    Fundamental / Macro / AI Chat tabs
    ├── src/app/settings/page.tsx    Health check + API key guide + CF Tunnel
    ├── src/components/charts/       TradingViewWidget + QuoteTicker
    └── src/lib/api.ts               Typed API client + WebSocket helper
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)