### PR TITLE
feat(llm): add Atlas Cloud provider support

### DIFF
--- a/skills/alphaear-predictor/scripts/utils/llm/factory.py
+++ b/skills/alphaear-predictor/scripts/utils/llm/factory.py
@@ -53,6 +53,28 @@ def get_model(model_provider: str, model_id: str, **kwargs):
             **kwargs
         )
 
+    elif model_provider in {'atlas', 'atlascloud'}:
+        api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            print('Warning: ATLASCLOUD_API_KEY not set.')
+
+        default_role_map = {
+            "system": "system",
+            "user": "user",
+            "assistant": "assistant",
+            "tool": "tool",
+            "model": "assistant",
+        }
+        role_map = kwargs.pop("role_map", default_role_map)
+
+        return OpenAIChat(
+            id=model_id,
+            base_url="https://api.atlascloud.ai/v1",
+            api_key=api_key,
+            role_map=role_map,
+            **kwargs
+        )
+
     elif model_provider == 'zai':
         api_key = os.getenv("ZAI_KEY_API")
         if not api_key:
@@ -111,4 +133,3 @@ def get_model(model_provider: str, model_id: str, **kwargs):
     
     else:
         raise ValueError(f"Unknown model provider: {model_provider}")
-

--- a/skills/alphaear-reporter/scripts/utils/llm/factory.py
+++ b/skills/alphaear-reporter/scripts/utils/llm/factory.py
@@ -53,6 +53,28 @@ def get_model(model_provider: str, model_id: str, **kwargs):
             **kwargs
         )
 
+    elif model_provider in {'atlas', 'atlascloud'}:
+        api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            print('Warning: ATLASCLOUD_API_KEY not set.')
+
+        default_role_map = {
+            "system": "system",
+            "user": "user",
+            "assistant": "assistant",
+            "tool": "tool",
+            "model": "assistant",
+        }
+        role_map = kwargs.pop("role_map", default_role_map)
+
+        return OpenAIChat(
+            id=model_id,
+            base_url="https://api.atlascloud.ai/v1",
+            api_key=api_key,
+            role_map=role_map,
+            **kwargs
+        )
+
     elif model_provider == 'zai':
         api_key = os.getenv("ZAI_KEY_API")
         if not api_key:
@@ -111,4 +133,3 @@ def get_model(model_provider: str, model_id: str, **kwargs):
     
     else:
         raise ValueError(f"Unknown model provider: {model_provider}")
-

--- a/skills/alphaear-search/scripts/llm/factory.py
+++ b/skills/alphaear-search/scripts/llm/factory.py
@@ -53,6 +53,28 @@ def get_model(model_provider: str, model_id: str, **kwargs):
             **kwargs
         )
 
+    elif model_provider in {'atlas', 'atlascloud'}:
+        api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            print('Warning: ATLASCLOUD_API_KEY not set.')
+
+        default_role_map = {
+            "system": "system",
+            "user": "user",
+            "assistant": "assistant",
+            "tool": "tool",
+            "model": "assistant",
+        }
+        role_map = kwargs.pop("role_map", default_role_map)
+
+        return OpenAIChat(
+            id=model_id,
+            base_url="https://api.atlascloud.ai/v1",
+            api_key=api_key,
+            role_map=role_map,
+            **kwargs
+        )
+
     elif model_provider == 'zai':
         api_key = os.getenv("ZAI_KEY_API")
         if not api_key:
@@ -111,4 +133,3 @@ def get_model(model_provider: str, model_id: str, **kwargs):
     
     else:
         raise ValueError(f"Unknown model provider: {model_provider}")
-

--- a/skills/alphaear-sentiment/scripts/llm/factory.py
+++ b/skills/alphaear-sentiment/scripts/llm/factory.py
@@ -53,6 +53,28 @@ def get_model(model_provider: str, model_id: str, **kwargs):
             **kwargs
         )
 
+    elif model_provider in {'atlas', 'atlascloud'}:
+        api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            print('Warning: ATLASCLOUD_API_KEY not set.')
+
+        default_role_map = {
+            "system": "system",
+            "user": "user",
+            "assistant": "assistant",
+            "tool": "tool",
+            "model": "assistant",
+        }
+        role_map = kwargs.pop("role_map", default_role_map)
+
+        return OpenAIChat(
+            id=model_id,
+            base_url="https://api.atlascloud.ai/v1",
+            api_key=api_key,
+            role_map=role_map,
+            **kwargs
+        )
+
     elif model_provider == 'zai':
         api_key = os.getenv("ZAI_KEY_API")
         if not api_key:
@@ -111,4 +133,3 @@ def get_model(model_provider: str, model_id: str, **kwargs):
     
     else:
         raise ValueError(f"Unknown model provider: {model_provider}")
-

--- a/skills/alphaear-signal-tracker/scripts/utils/llm/factory.py
+++ b/skills/alphaear-signal-tracker/scripts/utils/llm/factory.py
@@ -53,6 +53,28 @@ def get_model(model_provider: str, model_id: str, **kwargs):
             **kwargs
         )
 
+    elif model_provider in {'atlas', 'atlascloud'}:
+        api_key = os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            print('Warning: ATLASCLOUD_API_KEY not set.')
+
+        default_role_map = {
+            "system": "system",
+            "user": "user",
+            "assistant": "assistant",
+            "tool": "tool",
+            "model": "assistant",
+        }
+        role_map = kwargs.pop("role_map", default_role_map)
+
+        return OpenAIChat(
+            id=model_id,
+            base_url="https://api.atlascloud.ai/v1",
+            api_key=api_key,
+            role_map=role_map,
+            **kwargs
+        )
+
     elif model_provider == 'zai':
         api_key = os.getenv("ZAI_KEY_API")
         if not api_key:
@@ -111,4 +133,3 @@ def get_model(model_provider: str, model_id: str, **kwargs):
     
     else:
         raise ValueError(f"Unknown model provider: {model_provider}")
-


### PR DESCRIPTION
## Summary
- add an Atlas Cloud OpenAI-compatible provider to all five AlphaEar LLM factories
- support both `atlascloud` and the existing `atlas` shorthand
- use `ATLASCLOUD_API_KEY` with the standard Atlas Cloud API base URL and role mapping

## Validation
- provider contract checks across all five factories
- `python3 -m py_compile` across all five modified files
- Atlas Cloud model catalog contains `deepseek-ai/deepseek-v4-pro`
- live chat completion returned HTTP 200

## Scope
No README or documentation changes. No sponsor, logo, credits, or partner promotion.